### PR TITLE
Potential fix for code scanning alert no. 30: Log Injection

### DIFF
--- a/backend/src/main/java/com/csy/springbootauthbe/user/controller/AuthenticationController.java
+++ b/backend/src/main/java/com/csy/springbootauthbe/user/controller/AuthenticationController.java
@@ -21,28 +21,39 @@ public class AuthenticationController {
     private final AuthenticationService service;
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationController.class);
 
+    /**
+     * Sanitizes user input for logging by removing CR/LF/control characters.
+     * @param input User-supplied string to sanitize.
+     * @return Sanitized string safe for single-line logging.
+     */
+    private static String sanitizeForLog(String input) {
+        if (input == null) return null;
+        // Remove CR, LF, tabs, and any non-printable/control characters
+        return input.replaceAll("[\\r\\n\\t\\f\\u000B\\u0000-\\u001F\\u007F]+", " ");
+    }
+
     @PostMapping("/register")
     public ResponseEntity<AuthenticationResponse> register(@RequestBody RegisterRequest request) {
-        logger.info("Register request received for email: {}", request.getEmail());
+        logger.info("Register request received for email: {}", sanitizeForLog(request.getEmail()));
         try {
             AuthenticationResponse response = service.register(request);
-            logger.info("Register successful for email: {}", request.getEmail());
+            logger.info("Register successful for email: {}", sanitizeForLog(request.getEmail()));
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            logger.error("Register failed for email: {}. Error: {}", request.getEmail(), e.getMessage(), e);
+            logger.error("Register failed for email: {}. Error: {}", sanitizeForLog(request.getEmail()), e.getMessage(), e);
             throw e;
         }
     }
 
     @PostMapping("/login")
     public ResponseEntity<AuthenticationResponse> login(@RequestBody LoginRequest request) {
-        logger.info("Login request received for email: {}", request.getEmail());
+        logger.info("Login request received for email: {}", sanitizeForLog(request.getEmail()));
         try {
             AuthenticationResponse response = service.login(request);
-            logger.info("Login successful for email: {}", request.getEmail());
+            logger.info("Login successful for email: {}", sanitizeForLog(request.getEmail()));
             return ResponseEntity.ok(response);
         } catch (Exception e) {
-            logger.error("Login failed for email: {}. Error: {}", request.getEmail(), e.getMessage(), e);
+            logger.error("Login failed for email: {}. Error: {}", sanitizeForLog(request.getEmail()), e.getMessage(), e);
             throw e;
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/chowsowying/TutorLink/security/code-scanning/30](https://github.com/chowsowying/TutorLink/security/code-scanning/30)

To fix the log injection vulnerability, sanitize the user-provided email before logging. Since this is plain text logging, we should:  
- Remove, or escape, newline characters and other log control characters from the email string prior to logging.
- Make it clear in log output that the value is untrusted user input.

The best approach without changing existing functionality is to introduce a private static helper method (e.g., `sanitizeForLog`) in the controller class. This method should remove CR (`\r`), LF (`\n`), and similar characters from the string, ideally replacing them with a visible marker (such as `' '`), so that injected line breaks cannot create new log entries. Update all logging statements that log untrusted data (here, `request.getEmail()` within the controller) to sanitize the value before logging.

The method can be implemented directly in the shown file. No external dependencies are required. Any future logs containing user input should use this sanitizer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
